### PR TITLE
nbgrader 0.9.5 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - python
     - hatchling >=1.10.0
     - hatch-jupyter-builder >=0.7
-    - jupyterlab 4.3.4
   run:
     - python
     - alembic >=1.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,20 @@
-{% set version = "0.9.1" %}
+{% set name = "nbgrader" %}
+{% set version = "0.9.5" %}
 
 package:
-  name: nbgrader
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/n/nbgrader/nbgrader-{{ version }}.tar.gz
-  sha256: 88e3718fb4e6f75dd0b90afea3c5ad0abf14fd23ead4ce7a5c2be5eb6fa327d2
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1ea898f3b1cd15ebd1f407591ac94b454244566876f0bc8740f5b1d501dc076a
+  patches:
+    # See https://github.com/jupyter/nbgrader/issues/1948
+    - patches/0001-bump-jupyter-ydoc-dependency.patch
 
 build:
-  skip: true # [py<38 or s390x]
+  # caveat: no jupyterlab for py313 and 4.2.x
+  skip: true # [py<38]
   number: 0
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -18,11 +23,13 @@ build:
 
 requirements:
   host:
-    - hatch-jupyter-builder >=0.7
-    - hatchling >=1.10.0
     - pip
     - python
+    - hatchling >=1.10.0
+    - hatch-jupyter-builder >=0.7
+    - jupyterlab >=4.3.0,<5
   run:
+    - python
     - alembic >=1.7
     - ipython >=8.10.0
     - ipywidgets >=7.6
@@ -30,23 +37,24 @@ requirements:
     - jsonschema >=3
     - jupyter_client <9
     - jupyter_server >=2
-    - jupyterlab >=4.0.2,<5
+    # Officially jupyterlab>=4.2.0,<5 but to align with ydoc
+    # dependency patch above
+    - jupyterlab >=4.3.0,<5
     - jupyterlab_server
     - nbclient >=0.6.1
     - nbconvert >=6
-    - notebook >=7.0.2,<8
-    - python
+    - notebook >=7.2.0,<8
     - python-dateutil >=2.8
-    - pyyaml >=6.0
     - rapidfuzz >=1.8
     - requests >=2.26
+    - setuptools
     - sqlalchemy >=1.4,<3
+    - pyyaml >=6.0
 
 test:
   requires:
     - pip
-    - m2-grep  # [win]
-    - jupyterlab
+    - msys2-grep  # [win]
   imports:
     - nbgrader
   commands:
@@ -61,7 +69,9 @@ test:
     - grep -iE "nbgrader.server_extensions.{{ ext }}.*OK" server_extensions
     - grep -iE "nbgrader.server_extensions.{{ ext }}.*enabled" server_extensions
     {% endfor %}
-    - grep -iE "nbgrader.*OK.*nbgrader" labextensions
+    # The labextension output format changed in 4.2?
+    #- grep -iE "nbgrader.*OK.*nbgrader" labextensions
+    - grep -iE "nbgrader.*enabled.*OK" labextensions
 
 about:
   home: https://github.com/jupyter/nbgrader
@@ -71,6 +81,12 @@ about:
     - LICENSE
     - nbgrader/labextension/static/third-party-licenses.json
   summary: A system for assigning and grading Jupyter notebooks
+  description: |
+    nbgrader is a tool that facilitates creating and grading
+    assignments in the Jupyter notebook. It allows instructors to
+    easily create notebook-based assignments that include both coding
+    exercises and written free-responses. nbgrader then also provides
+    a streamlined interface for quickly grading completed assignments.
   doc_url: https://nbgrader.readthedocs.io
   dev_url: https://github.com/jupyter/nbgrader
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,15 @@ build:
     - nbgrader = nbgrader.apps.nbgraderapp:main
 
 requirements:
+  build:
+    - patch     # [not win]
+    - msys2-patch  # [win]
   host:
     - pip
     - python
     - hatchling >=1.10.0
     - hatch-jupyter-builder >=0.7
-    - jupyterlab >=4.3.0,<5
+    - jupyterlab 4.3.4
   run:
     - python
     - alembic >=1.7
@@ -99,3 +102,6 @@ extra:
     - BertR
     - SylvainCorlay
     - bollwyvl
+  skip-lints:
+    - python_build_tool_in_run
+    - patch_must_be_in_build   # the linter knows about m2-patch

--- a/recipe/patches/0001-bump-jupyter-ydoc-dependency.patch
+++ b/recipe/patches/0001-bump-jupyter-ydoc-dependency.patch
@@ -1,0 +1,34 @@
+From de693bd1e2ec5a023e2dad62fb2f010053e43bca Mon Sep 17 00:00:00 2001
+From: Ian Fitchet <ifitchet@anaconda.com>
+Date: Fri, 9 May 2025 14:47:25 +0100
+Subject: [PATCH] bump jupyter/ydoc dependency
+
+---
+ package.json | 2 +-
+ yarn.lock    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff -ruN a/nbgrader/labextension/package.json b/nbgrader/labextension/package.json
+--- a/nbgrader/labextension/package.json	2020-02-02 00:00:00.000000000 +0000
++++ b/nbgrader/labextension/package.json	2025-05-09 13:43:43.450389493 +0100
+@@ -45,7 +45,7 @@
+   "dependencies": {
+     "@jupyter-notebook/application": "^7.2.0",
+     "@jupyter-notebook/tree": "^7.2.0",
+-    "@jupyter/ydoc": "^2.0.0",
++    "@jupyter/ydoc": "^3.0.0",
+     "@jupyterlab/application": "^4.2.0",
+     "@jupyterlab/apputils": "^4.3.0",
+     "@jupyterlab/cells": "^4.2.0",
+diff -ruN a/package.json b/package.json
+--- a/package.json	2020-02-02 00:00:00.000000000 +0000
++++ b/package.json	2025-05-09 13:43:31.959967013 +0100
+@@ -45,7 +45,7 @@
+   "dependencies": {
+     "@jupyter-notebook/application": "^7.2.0",
+     "@jupyter-notebook/tree": "^7.2.0",
+-    "@jupyter/ydoc": "^2.0.0",
++    "@jupyter/ydoc": "^3.0.0",
+     "@jupyterlab/application": "^4.2.0",
+     "@jupyterlab/apputils": "^4.3.0",
+     "@jupyterlab/cells": "^4.2.0",


### PR DESCRIPTION
nbgrader 0.9.5 

**Destination channel:** Defaults

### Links

- [PKG-7297]
- dev_url:        https://github.com/jupyter/nbgrader/tree/v0.9.5
- conda_forge:    https://github.com/conda-forge/nbgrader-feedstock
- pypi:           https://pypi.org/project/nbgrader/0.9.5
- pypi inspector: https://inspector.pypi.io/project/nbgrader/0.9.5

### Explanation of changes:

- new version number
- remove `abs.yaml` -- `aggregate_check: false` not relevant?
- patch to align `ydoc` dependency with `jupyterlab` 4.3+ (see below)

It looks like the last two `nbgrader` versions (check the dates):

```
 1) 0.9.5                Fri, 17 Jan 2025 14:18:30 GMT
 2) 0.9.4                Mon, 18 Nov 2024 12:32:31 GMT
 3) 0.9.3                Thu, 20 Jun 2024 19:04:49 GMT
 4) 0.9.2                Tue, 26 Mar 2024 10:47:25 GMT
 5) 0.9.1                Tue, 05 Sep 2023 12:34:49 GMT
```

where the dependency edits are:

```
0.9.1 7922f769c (Nicolas Brichet    2023-09-05  49)     "@jupyter/ydoc": "^1.0.2",
0.9.2 720f16bef (Nicolas Brichet    2024-03-04  49)     "@jupyter/ydoc": "^1.1.1",
0.9.3 06630f7e0 (Nicolas Brichet    2024-06-18  48)     "@jupyter/ydoc": "^2.0.0",
```

failed to pick up the `jupyterlab` dependency edits in 4.3.0:

```
4.0.0 28157c3a545 jupyterlab/staging/package.json  (jtpio              2023-04-25  23)     "@jupyter/ydoc": "~1.0.2",
4.1.0 1c1058cc493 jupyterlab/staging/package.json  (krassowski         2023-11-12  25)     "@jupyter/ydoc": "~1.1.1",
4.2.0 e1ee2d4d2bd jupyterlab/staging/package.json  (krassowski         2024-03-25  25)     "@jupyter/ydoc": "^2.0.1"
4.3.0 67cb8f8347f jupyterlab/staging/package.json  (krassowski         2024-08-11  25)     "@jupyter/ydoc": "^3.0.0-a3
```

There is an open [issue](https://github.com/jupyter/nbgrader/issues/1948) for it.

In the meanwhile, the file you need to patch, `nbgrader/labextension/package.json`, is deliberately excluded from the repo (see `.gitignores` and `nbgrader/labextension`) so the patching is more manually crafted.

Also, the format of the `jupyter labextension list` output appears to have changed in 4.2-ish -- meaning the test that `grep`ed for a particular answer failed.

Alternatively, we could have restricted `nbgrader` to `jupyterlab>=4.2.0,<4.3.0` which implies no `py313`.

Finally, as an observation, there are no useful tests other than catching whether extension lists look right.  The [demos](https://github.com/jupyter/nbgrader/tree/v0.9.5/demos) in the repo assume there is a JupyterHub Server available to play with.

[PKG-7297]: https://anaconda.atlassian.net/browse/PKG-7297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ